### PR TITLE
Some fixes

### DIFF
--- a/example.js
+++ b/example.js
@@ -17,9 +17,9 @@ console.log('verify result of:'+code,verifyResult1);
 var verifyResult2=nya.verifyCode(secret,"123456");
 console.log('verify esult of:123456',verifyResult2);
 
-var QRaddr=nya.getQRCodeGoogleUrl('poi test/'+secret,secret,'poi');
+var QRaddr=nya.getGoogleQRCodeAPIUrl('poi test/'+secret,secret,'poi');
 console.log('QR address:',QRaddr);
 console.log('\n\n');
 console.log('================fixed test================');
 console.log('code of QYTACVMTAYCPZDYS',nya.getCode('QYTACVMTAYCPZDYS'));
-console.log('QR of QYTACVMTAYCPZDYS',nya.getQRCodeGoogleUrl('poi test/QYTACVMTAYCPZDYS','QYTACVMTAYCPZDYS','poi'));
+console.log('QR of QYTACVMTAYCPZDYS',nya.getGoogleQRCodeAPIUrl('poi test/QYTACVMTAYCPZDYS','QYTACVMTAYCPZDYS','poi'));

--- a/example_newSec.js
+++ b/example_newSec.js
@@ -4,7 +4,7 @@ var authenticator=require('./index.js').authenticator;
 var nya=new authenticator();
 var secretLnegth=32;
 var secret=nya.createSecret(secretLnegth);
-var url=nya.getQRCodeGoogleUrl('random/code',secret,'test');
+var url=nya.getGoogleQRCodeAPIUrl('random/code',secret,'test');
 
 function refresh(){
 	console.log(Date());

--- a/index.js
+++ b/index.js
@@ -93,14 +93,14 @@ class GoogleAuthenticator{
 		return '0'.repeat(this.codeLength-code.length)+code;
 	}
 	getQRCodeText(name,secret,title){
-		let urlencoded=encodeURI(`otpauth://totp/${name}?secret=${secret}`);
+		let urlencoded=`otpauth://totp/${name}?secret=${secret}`;
 		if(title){
-			urlencoded+=encodeURI('&issuer='+encodeURI(title));
+			urlencoded+=`&issuer=${title}`;
 		}
-		return urlencoded;
+		return encodeURI(urlencoded);
 	}
 	getGoogleQRCodeAPIUrl(name,secret,title){
-		return 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl='+this.getQRCodeText(name,secret,title);
+		return 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl='+encodeURIComponent(this.getQRCodeText(name,secret,title));
 	}
 	verifyCode(secret,code,discrepancy,currentTimeSlice){
 		(typeof code!=='number')&&(code=code.toString());


### PR DESCRIPTION
* Fix `getQRCodeGoogleUrl` to `getGoogleQRCodeAPIUrl` in examples
* Encoding fix in the `getQRCodeText` and` getGoogleQRCodeAPIUrl` functions for `name` and` title` parameters if they contain spaces (and possibly other special characters)